### PR TITLE
Implement SubscribeSuccess and SubscribeFailure messages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 organization := "com.sandinh"
 name := "paho-akka"
 
-version := "1.2.0"
+version := "1.2.0-CHARIOT-FORK-REV-1"
 
 scalaVersion := "2.11.7"
 //TODO re-enable cross when scala release version 2.12

--- a/src/test/scala/com/sandinh/paho/akka/BenchSpec.scala
+++ b/src/test/scala/com/sandinh/paho/akka/BenchSpec.scala
@@ -28,6 +28,7 @@ class BenchSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSend
       subs ! Run
       within(10.seconds) {
         expectMsgType[SubscribeAck]
+        expectMsgType[SubscribeSuccess.type]
       }
 
       val pub = system.actorOf(Props(classOf[PubActor], count, qos))
@@ -79,8 +80,10 @@ private class SubsActor(reporTo: ActorRef, qos: Int) extends Actor with Common {
   def receive = {
     case Run => pubsub ! Subscribe(topic, self, qos)
     case msg @ SubscribeAck(Subscribe(`topic`, `self`, `qos`)) =>
-      context become ready
       reporTo ! msg
+    case msg @ SubscribeSuccess =>
+      reporTo ! msg
+      context become ready
   }
 
   private[this] var receivedCount = 0


### PR DESCRIPTION
that get sent some time after SubscribeAck, when the subscription is
complete and ready to receive publishes. Updated test to account for
this.